### PR TITLE
suppress non-consecutive header warnings and localhost linkcheck errors

### DIFF
--- a/project/docs/conf.py.j2
+++ b/project/docs/conf.py.j2
@@ -79,6 +79,8 @@ rst_prolog = """
 
 # -- General configuration ---------------------------------------------------
 
+linkcheck_ignore = [r"http://localhost:\d+"]
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
@@ -122,6 +124,8 @@ exclude_patterns = [
 ]
 
 autosummary_generate = False
+
+suppress_warnings = ["myst.header"]
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
linkcheck ignore regex fixes scenarios where the docs reference localhost links and linkcheck tries to follow them.

myst.header warning suppression fixes errors when the docs try to import the main changelog markdown file